### PR TITLE
Added deployment scripts

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -52,6 +52,11 @@ pushd "$SOFTWARE_DIR"
 download_and_unzip fastqc_v0.11.3.zip
 popd
 
+# seqtk
+pushd "$SOFTWARE_DIR"
+download_and_unzip seqtk_4feb6e8144.zip
+popd
+
 
 ## STEP 3: Decontamination
 
@@ -63,6 +68,11 @@ pip install --upgrade pysam
 # Bowtie2
 pushd "$SOFTWARE_DIR"
 download_and_unzip bowtie2-2.2.6-linux-x86_64.zip
+popd
+
+# Bwa
+pushd "$SOFTWARE_DIR"
+download_and_unzip bwa-0.7.12.zip
 popd
 
 # Human, PhiX174 genomes

--- a/deploy.sh
+++ b/deploy.sh
@@ -12,6 +12,9 @@ set -x
 set -e
 set -u
 
+VERSION="1.0"
+
+
 # Software and data directories
 
 SOFTWARE_DIR="$HOME/software"
@@ -24,7 +27,7 @@ mkdir -p "$BIODATA_DIR"
 # Functions
 
 download_and_unzip () {
-    wget "http://microb234.med.upenn.edu/shotgun-pipeline-files/$1"
+    wget "http://hivsystemsbiology.org/files/shotgun-pipeline/${VERSION}/${1}"
     unzip "$1"
     rm "$1"
 }

--- a/deploy.sh
+++ b/deploy.sh
@@ -60,7 +60,8 @@ popd
 
 # decontam
 pip install --upgrade \
-    git+https://github.com/PennChopMicrobiomeProgram/illqc.git
+    git+https://github.com/PennChopMicrobiomeProgram/decontam.git
+pip install --upgrade pysam
 
 # Bowtie2
 pushd "$SOFTWARE_DIR"
@@ -68,14 +69,13 @@ download_and_unzip \
     http://sourceforge.net/projects/bowtie-bio/files/bowtie2/2.2.6/bowtie2-2.2.6-linux-x86_64.zip
 popd
 
-# Human genome
+# Human, PhiX174 genomes
 pushd "$BIODATA_DIR"
-download_and_unzip ftp://ftp.ccb.jhu.edu/pub/data/bowtie2_indexes/hg18.1.zip
-download_and_unzip ftp://ftp.ccb.jhu.edu/pub/data/bowtie2_indexes/hg18.2.zip
-download_and_unzip ftp://ftp.ccb.jhu.edu/pub/data/bowtie2_indexes/hg18.3.zip
+download_and_unzip \
+    http://microb234.med.upenn.edu/shotgun-pipeline-files/hg18.zip
+download_and_unzip \
+    http://microb234.med.upenn.edu/shotgun-pipeline-files/phix.zip
 popd
-
-# PhiX174 genome
 
 
 ## STEP 4: Taxonomic assignment
@@ -85,7 +85,11 @@ pip install --upgrade \
     git+https://github.com/PennChopMicrobiomeProgram/PhylogeneticProfiler.git
 
 # metaphlan2
-# metaphlan2 dependencies
+pushd "$SOFTWARE_DIR"
+download_and_unzip https://bitbucket.org/biobakery/metaphlan2/get/default.zip
+popd
+pip install --upgrade numpy
+pip install --upgrade biom-format
 
 
 ## STEP 5: Functional assignment
@@ -95,5 +99,12 @@ pip install --upgrade \
     https://github.com/PennChopMicrobiomeProgram/PathwayAbundanceFinder.git
 
 # Rapsearch2
+pushd "$SOFTWARE_DIR"
+download_and_unzip \
+    http://sourceforge.net/projects/rapsearch2/files/RAPSearch2.23_64bits.tar.gz
+popd
+
 # KEGG database
+download_and_unzip \
+    http://microb234.med.upenn.edu/shotgun-pipeline-files/kegg.zip
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# Deploy all software necessary for ShotgunPipeline
+#
+# Pre-requisites not included in deployment:
+# python (>= 2.7.3)
+# pip
+
+set -x
+set -e
+set -u
+
+# Software and data directories
+
+SOFTWARE_DIR="$HOME/software"
+mkdir -p "$SOFTWARE_DIR"
+
+BIODATA_DIR="$HOME/biodata"
+mkdir -p "$BIODATA_DIR"
+
+# Virtualenv, virtualenvwrapper
+pip install --user --upgrade virtualenv
+pip install --user --upgrade virtualenvwrapper
+
+####################################################
+## BASH CONFIG SECTION
+## This section should be added to your .bashrc file
+
+# Binary and lib paths used by pip
+# On OSX, these may be different
+# See http://stackoverflow.com/questions/7143077/how-can-i-install-packages-in-my-home-folder-with-pip
+PIP_BIN="$HOME/.local/bin"
+PIP_LIB="$HOME/.local/lib/python2.7/site-packages"
+
+# Add the pip install directories to PATH and PYTHONPATH
+export PATH="${PIP_BIN}:$PATH"
+export PYTHONPATH="${PIP_LIB}:$PYTHONPATH"
+
+# Initialize virtualenvwrapper
+export WORKON_HOME="$HOME/.virtualenvs"
+source "${PIP_BIN}/virtualenvwrapper.sh"
+
+## END BASH CONFIG SECTION
+####################################################
+
+
+# Make a new virtual environment
+# Pipeline should be executed in this virtual environment
+mkvirtualenv shotgun-pipeline
+
+
+## STEP 1: Demultiplexing
+
+# dnabc
+pip install --upgrade \
+    git+https://github.com/PennChopMicrobiomeProgram/dnabc.git
+
+
+## STEP 2: Quality control
+
+# IllQC
+pip install --upgrade \
+    git+https://github.com/PennChopMicrobiomeProgram/illqc.git
+
+# Trimmomatic
+pushd "$SOFTWARE_DIR"
+wget \
+    http://www.usadellab.org/cms/uploads/supplementary/Trimmomatic/Trimmomatic-0.33.zip
+unzip Trimmomatic-0.33.zip
+rm Trimmomatic-0.33.zip
+popd
+
+# FastQC
+pushd "$SOFTWARE_DIR"
+wget \
+    http://www.bioinformatics.babraham.ac.uk/projects/fastqc/fastqc_v0.11.3.zip
+unzip fastqc_v0.11.3.zip
+rm fastqc_v0.11.3.zip
+popd
+
+
+## STEP 3: Decontamination
+
+# decontam
+pip install --upgrade \
+    git+https://github.com/PennChopMicrobiomeProgram/illqc.git
+
+# Bowtie2
+pushd "$SOFTWARE_DIR"
+wget \
+    http://sourceforge.net/projects/bowtie-bio/files/bowtie2/2.2.6/bowtie2-2.2.6-linux-x86_64.zip
+unzip bowtie2-2.2.6-linux-x86_64.zip
+rm bowtie2-2.2.6-linux-x86_64.zip
+popd
+
+# Human genome
+pushd "$BIODATA_DIR"
+wget ftp://ftp.ccb.jhu.edu/pub/data/bowtie2_indexes/hg18.1.zip
+wget ftp://ftp.ccb.jhu.edu/pub/data/bowtie2_indexes/hg18.2.zip
+wget ftp://ftp.ccb.jhu.edu/pub/data/bowtie2_indexes/hg18.3.zip
+popd

--- a/deploy.sh
+++ b/deploy.sh
@@ -21,12 +21,9 @@ mkdir -p "$BIODATA_DIR"
 # Functions
 
 download_and_unzip () {
-    # Download and unzip a file into a specified directory.
-    URL="$1"
-    FILENAME=$( basename "$URL" )
-    wget "$URL"
-    unzip "$FILENAME"
-    rm "$FILENAME"
+    wget "http://microb234.med.upenn.edu/shotgun-pipeline-files/$1"
+    unzip "$1"
+    rm "$1"
 }
 
 
@@ -45,14 +42,12 @@ pip install --upgrade \
 
 # Trimmomatic
 pushd "$SOFTWARE_DIR"
-download_and_unzip \
-    http://www.usadellab.org/cms/uploads/supplementary/Trimmomatic/Trimmomatic-0.33.zip
+download_and_unzip Trimmomatic-0.33.zip
 popd
 
 # FastQC
 pushd "$SOFTWARE_DIR"
-download_and_unzip \
-    http://www.bioinformatics.babraham.ac.uk/projects/fastqc/fastqc_v0.11.3.zip
+download_and_unzip fastqc_v0.11.3.zip
 popd
 
 
@@ -65,17 +60,15 @@ pip install --upgrade pysam
 
 # Bowtie2
 pushd "$SOFTWARE_DIR"
-download_and_unzip \
-    http://sourceforge.net/projects/bowtie-bio/files/bowtie2/2.2.6/bowtie2-2.2.6-linux-x86_64.zip
+download_and_unzip bowtie2-2.2.6-linux-x86_64.zip
 popd
 
 # Human, PhiX174 genomes
 pushd "$BIODATA_DIR"
-download_and_unzip \
-    http://microb234.med.upenn.edu/shotgun-pipeline-files/hg18.zip
-download_and_unzip \
-    http://microb234.med.upenn.edu/shotgun-pipeline-files/phix.zip
+download_and_unzip hg18.zip
+download_and_unzip phix.zip
 popd
+# TODO: build indexes
 
 
 ## STEP 4: Taxonomic assignment
@@ -86,7 +79,7 @@ pip install --upgrade \
 
 # metaphlan2
 pushd "$SOFTWARE_DIR"
-download_and_unzip https://bitbucket.org/biobakery/metaphlan2/get/default.zip
+download_and_unzip metaphlan2.zip
 popd
 pip install --upgrade numpy
 pip install --upgrade biom-format
@@ -107,4 +100,4 @@ popd
 # KEGG database
 download_and_unzip \
     http://microb234.med.upenn.edu/shotgun-pipeline-files/kegg.zip
-
+# TODO: build indexes

--- a/deploy.sh
+++ b/deploy.sh
@@ -93,11 +93,9 @@ pip install --upgrade \
 
 # Rapsearch2
 pushd "$SOFTWARE_DIR"
-download_and_unzip \
-    http://sourceforge.net/projects/rapsearch2/files/RAPSearch2.23_64bits.tar.gz
+download_and_unzip RAPSearch2.23_64bits.zip
 popd
 
 # KEGG database
-download_and_unzip \
-    http://microb234.med.upenn.edu/shotgun-pipeline-files/kegg.zip
+download_and_unzip kegg.zip
 # TODO: build indexes

--- a/deploy.sh
+++ b/deploy.sh
@@ -91,7 +91,7 @@ pip install --upgrade biom-format
 
 # PathwayAbundanceFinder
 pip install --upgrade \
-    https://github.com/PennChopMicrobiomeProgram/PathwayAbundanceFinder.git
+    git+https://github.com/PennChopMicrobiomeProgram/PathwayAbundanceFinder.git
 
 # Rapsearch2
 pushd "$SOFTWARE_DIR"

--- a/deploy.sh
+++ b/deploy.sh
@@ -17,35 +17,17 @@ mkdir -p "$SOFTWARE_DIR"
 BIODATA_DIR="$HOME/biodata"
 mkdir -p "$BIODATA_DIR"
 
-# Virtualenv, virtualenvwrapper
-pip install --user --upgrade virtualenv
-pip install --user --upgrade virtualenvwrapper
 
-####################################################
-## BASH CONFIG SECTION
-## This section should be added to your .bashrc file
+# Functions
 
-# Binary and lib paths used by pip
-# On OSX, these may be different
-# See http://stackoverflow.com/questions/7143077/how-can-i-install-packages-in-my-home-folder-with-pip
-PIP_BIN="$HOME/.local/bin"
-PIP_LIB="$HOME/.local/lib/python2.7/site-packages"
-
-# Add the pip install directories to PATH and PYTHONPATH
-export PATH="${PIP_BIN}:$PATH"
-export PYTHONPATH="${PIP_LIB}:$PYTHONPATH"
-
-# Initialize virtualenvwrapper
-export WORKON_HOME="$HOME/.virtualenvs"
-source "${PIP_BIN}/virtualenvwrapper.sh"
-
-## END BASH CONFIG SECTION
-####################################################
-
-
-# Make a new virtual environment
-# Pipeline should be executed in this virtual environment
-mkvirtualenv shotgun-pipeline
+download_and_unzip () {
+    # Download and unzip a file into a specified directory.
+    URL="$1"
+    FILENAME=$( basename "$URL" )
+    wget "$URL"
+    unzip "$FILENAME"
+    rm "$FILENAME"
+}
 
 
 ## STEP 1: Demultiplexing
@@ -63,18 +45,14 @@ pip install --upgrade \
 
 # Trimmomatic
 pushd "$SOFTWARE_DIR"
-wget \
+download_and_unzip \
     http://www.usadellab.org/cms/uploads/supplementary/Trimmomatic/Trimmomatic-0.33.zip
-unzip Trimmomatic-0.33.zip
-rm Trimmomatic-0.33.zip
 popd
 
 # FastQC
 pushd "$SOFTWARE_DIR"
-wget \
+download_and_unzip \
     http://www.bioinformatics.babraham.ac.uk/projects/fastqc/fastqc_v0.11.3.zip
-unzip fastqc_v0.11.3.zip
-rm fastqc_v0.11.3.zip
 popd
 
 
@@ -86,15 +64,36 @@ pip install --upgrade \
 
 # Bowtie2
 pushd "$SOFTWARE_DIR"
-wget \
+download_and_unzip \
     http://sourceforge.net/projects/bowtie-bio/files/bowtie2/2.2.6/bowtie2-2.2.6-linux-x86_64.zip
-unzip bowtie2-2.2.6-linux-x86_64.zip
-rm bowtie2-2.2.6-linux-x86_64.zip
 popd
 
 # Human genome
 pushd "$BIODATA_DIR"
-wget ftp://ftp.ccb.jhu.edu/pub/data/bowtie2_indexes/hg18.1.zip
-wget ftp://ftp.ccb.jhu.edu/pub/data/bowtie2_indexes/hg18.2.zip
-wget ftp://ftp.ccb.jhu.edu/pub/data/bowtie2_indexes/hg18.3.zip
+download_and_unzip ftp://ftp.ccb.jhu.edu/pub/data/bowtie2_indexes/hg18.1.zip
+download_and_unzip ftp://ftp.ccb.jhu.edu/pub/data/bowtie2_indexes/hg18.2.zip
+download_and_unzip ftp://ftp.ccb.jhu.edu/pub/data/bowtie2_indexes/hg18.3.zip
 popd
+
+# PhiX174 genome
+
+
+## STEP 4: Taxonomic assignment
+
+# PhylogeneticProfiler
+pip install --upgrade \
+    git+https://github.com/PennChopMicrobiomeProgram/PhylogeneticProfiler.git
+
+# metaphlan2
+# metaphlan2 dependencies
+
+
+## STEP 5: Functional assignment
+
+# PathwayAbundanceFinder
+pip install --upgrade \
+    https://github.com/PennChopMicrobiomeProgram/PathwayAbundanceFinder.git
+
+# Rapsearch2
+# KEGG database
+

--- a/deploy.sh
+++ b/deploy.sh
@@ -2,6 +2,7 @@
 # Deploy all software necessary for ShotgunPipeline
 #
 # Does not (yet) build search indexes from FASTA files.
+# Does not (yet) write configuration files for the pipeline.
 #
 # Pre-requisites not included in deployment:
 # python (>= 2.7.3)
@@ -77,10 +78,9 @@ popd
 
 # Human, PhiX174 genomes
 pushd "$BIODATA_DIR"
-download_and_unzip hg18.zip
+download_and_unzip hg38.zip
 download_and_unzip phix.zip
 popd
-# TODO: build indexes
 
 
 ## STEP 4: Taxonomic assignment

--- a/deploy.sh
+++ b/deploy.sh
@@ -91,7 +91,7 @@ pip install --upgrade \
 
 # metaphlan2
 pushd "$SOFTWARE_DIR"
-download_and_unzip metaphlan2.zip
+download_and_unzip metaphlan2_61ad257cc091.zip
 popd
 pip install --upgrade numpy
 pip install --upgrade biom-format

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # Deploy all software necessary for ShotgunPipeline
 #
+# Does not (yet) build search indexes from FASTA files.
+#
 # Pre-requisites not included in deployment:
 # python (>= 2.7.3)
 # pip
@@ -97,5 +99,6 @@ download_and_unzip RAPSearch2.23_64bits.zip
 popd
 
 # KEGG database
+pushd "$BIODATA_DIR"
 download_and_unzip kegg.zip
-# TODO: build indexes
+popd

--- a/deploy_file_archive.sh
+++ b/deploy_file_archive.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
 # Create software file archive needed for shotgun pipeline deployment.
 #
-# At this point, does not download data files for deployment.  These
-# are expected to be available from the same directory as the software
-# files.
+# For software downloaded as source, this script creates an executable
+# and re-zips the results.
 #
-# Data files expected by deployment script are:
+# This script does not download data files for deployment.  The
+# deployment script expects the data files to be available from the
+# same directory as the software files.
+#
+# Data files expected by the deployment script:
 #  - hg18.zip (Human genome in FASTA format)
 #  - phix.zip (Phi X 174 genome in FASTA format)
 #  - kegg.zip (KEGG protein database in FASTA format)
@@ -16,13 +19,17 @@ wget http://www.usadellab.org/cms/uploads/supplementary/Trimmomatic/Trimmomatic-
 wget http://www.bioinformatics.babraham.ac.uk/projects/fastqc/fastqc_v0.11.3.zip
 wget http://sourceforge.net/projects/bowtie-bio/files/bowtie2/2.2.6/bowtie2-2.2.6-linux-x86_64.zip
 
-# Rename the metaphlan2 file to something better than default.zip
+
+# MetaPhlan2
 wget https://bitbucket.org/biobakery/metaphlan2/get/default.zip
 mv default.zip metaphlan2.zip
 
-# Need to compile an re-zip the RAPSearch file.  The compilation
-# method below works only for Linux.  For OSX, we need to replace the
-# BOOST library files in the Src directory with ones compiled for OSX.
+
+# RAPSearch2
+# Note for building on OSX: the BOOST library files in the Src
+# directory need to be replaced with ones compiled for OSX.  I found
+# that downloading the BOOST library source code and manually building
+# the library files worked best.
 wget http://sourceforge.net/projects/rapsearch2/files/RAPSearch2.23_64bits.tar.gz
 tar xvzf RAPSearch2.23_64bits.tar.gz
 pushd RAPSearch2.23_64bits
@@ -31,3 +38,25 @@ popd
 zip -r RAPSearch2.23_64bits.zip RAPSearch2.23_64bits
 rm RAPSearch2.23_64bits.tar.gz
 rm -R RAPSearch2.23_64bits
+
+
+# seqtk
+wget https://github.com/lh3/seqtk/archive/4feb6e8144.zip
+unzip 4feb6e8144.zip
+pushd seqtk-4feb6e81444ab6bc44139dd3a125068f81ae4ad8
+make
+popd
+zip -r seqtk_4feb6e8144.zip seqtk-4feb6e81444ab6bc44139dd3a125068f81ae4ad8
+rm 4feb6e8144.zip
+rm -R seqtk-4feb6e81444ab6bc44139dd3a125068f81ae4ad8
+
+
+# Bwa
+wget http://sourceforge.net/projects/bio-bwa/files/bwa-0.7.12.tar.bz2
+tar xvjf bwa-0.7.12.tar.bz2
+pushd bwa-0.7.12
+make
+popd
+zip -r bwa-0.7.12.zip bwa-0.7.12
+rm bwa-0.7.12.tar.bz2
+rm -R bwa-0.7.12

--- a/deploy_file_archive.sh
+++ b/deploy_file_archive.sh
@@ -22,8 +22,8 @@ wget http://sourceforge.net/projects/bowtie-bio/files/bowtie2/2.2.6/bowtie2-2.2.
 
 
 # MetaPhlan2
-wget https://bitbucket.org/biobakery/metaphlan2/get/default.zip
-mv default.zip metaphlan2.zip
+wget https://bitbucket.org/biobakery/metaphlan2/get/61ad257cc091.zip
+mv 61ad257cc091.zip metaphlan2_61ad257cc091.zip
 
 
 # RAPSearch2

--- a/deploy_file_archive.sh
+++ b/deploy_file_archive.sh
@@ -9,11 +9,12 @@
 # same directory as the software files.
 #
 # Data files expected by the deployment script:
-#  - hg18.zip (Human genome in FASTA format)
+#  - hg38.zip (Human genome in FASTA format)
 #  - phix.zip (Phi X 174 genome in FASTA format)
 #  - kegg.zip (KEGG protein database in FASTA format)
 set -x
 set -e
+
 
 wget http://www.usadellab.org/cms/uploads/supplementary/Trimmomatic/Trimmomatic-0.33.zip
 wget http://www.bioinformatics.babraham.ac.uk/projects/fastqc/fastqc_v0.11.3.zip

--- a/deploy_file_archive.sh
+++ b/deploy_file_archive.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Create software file archive needed for shotgun pipeline deployment.
+#
+# At this point, does not download data files for deployment.  These
+# are expected to be available from the same directory as the software
+# files.
+#
+# Data files expected by deployment script are:
+#  - hg18.zip (Human genome in FASTA format)
+#  - phix.zip (Phi X 174 genome in FASTA format)
+#  - kegg.zip (KEGG protein database in FASTA format)
+set -x
+set -e
+
+wget http://www.usadellab.org/cms/uploads/supplementary/Trimmomatic/Trimmomatic-0.33.zip
+wget http://www.bioinformatics.babraham.ac.uk/projects/fastqc/fastqc_v0.11.3.zip
+wget http://sourceforge.net/projects/bowtie-bio/files/bowtie2/2.2.6/bowtie2-2.2.6-linux-x86_64.zip
+
+# Rename the metaphlan2 file to something better than default.zip
+wget https://bitbucket.org/biobakery/metaphlan2/get/default.zip
+mv default.zip metaphlan2.zip
+
+# Need to compile an re-zip the RAPSearch file.  The compilation
+# method below works only for Linux.  For OSX, we need to replace the
+# BOOST library files in the Src directory with ones compiled for OSX.
+wget http://sourceforge.net/projects/rapsearch2/files/RAPSearch2.23_64bits.tar.gz
+tar xvzf RAPSearch2.23_64bits.tar.gz
+pushd RAPSearch2.23_64bits
+./install
+popd
+zip -r RAPSearch2.23_64bits.zip RAPSearch2.23_64bits
+rm RAPSearch2.23_64bits.tar.gz
+rm -R RAPSearch2.23_64bits

--- a/deploy_virtualenv.sh
+++ b/deploy_virtualenv.sh
@@ -1,0 +1,47 @@
+#!/bin/echo Please run this file with the source command
+# Deploy a python virtual environment for ShotgunPipeline
+#
+# Pre-requisites not included in deployment:
+# python (>= 2.7.3)
+# pip
+
+set -x
+
+# Don't set -e because we are sourcing this script
+
+# Don't set -u because several variables may legitimately be undefined
+# as of first use, such as PYTHONPATH and others in virtualenvwrapper.sh
+
+pip install --user --upgrade virtualenv
+pip install --user --upgrade virtualenvwrapper
+
+####################################################
+## BASH CONFIG SECTION
+## This section should be added to your .bashrc file
+
+# See here for paths used by pip install --user
+# http://stackoverflow.com/questions/7143077
+PLATFORM=`uname`
+if [ "$PLATFORM" == "Darwin" ]; then
+    PIP_BIN="$HOME/Library/Python/2.7/bin"
+    PIP_LIB="$HOME/Library/Python/2.7/lib/python/site-packages"
+else
+    PIP_BIN="$HOME/.local/bin"
+    PIP_LIB="$HOME/.local/lib/python2.7/site-packages"
+fi
+
+# Add the pip install directories to PATH and PYTHONPATH
+export PATH="${PIP_BIN}:$PATH"
+export PYTHONPATH="${PIP_LIB}:$PYTHONPATH"
+
+# Initialize virtualenvwrapper
+export WORKON_HOME="$HOME/.virtualenvs"
+source "${PIP_BIN}/virtualenvwrapper.sh"
+
+## END BASH CONFIG SECTION
+####################################################
+
+virtualenv "${WORKON_HOME}/shotgun-pipeline"
+source "${WORKON_HOME}/shotgun-pipeline/bin/activate"
+
+set +x

--- a/deploy_virtualenv.sh
+++ b/deploy_virtualenv.sh
@@ -1,6 +1,21 @@
 #!/bin/echo Please run this file with the source command
 # Deploy a python virtual environment for ShotgunPipeline
 #
+# After this code is sourced, virtualenv and virtualenvwrapper should
+# be installed, and a new virtual environment, shotgun-pipeline,
+# should be activated.
+#
+# To work in the virtual environment for future sessions, you need to
+# define the variables PATH, PYTHONPATH, and WORKON_HOME as below.
+# After this, you need to source the virtualenvwrapper.sh script,
+# located in $PIP_BIN.  It is best to do these things in your .bashrc
+# file. The indicated section below can be copied/pasted directly into
+# .bashrc for this purpose.
+#
+# In future sessions, after the varibales are correctly defined and
+# virtualenvwrapper.sh is sourced, the virtual environment may be
+# activated with the command "workon shotgun-pipeline".
+#
 # Pre-requisites not included in deployment:
 # python (>= 2.7.3)
 # pip


### PR DESCRIPTION
Added scripts to help in deploying the shotgun pipeline:
1. Create a data & software directory for deployment (deploy_file_archive.sh)
2. Create and activate python virtual environment (deploy_virtualenv.sh)
3. Download and install software from deployment directory (deploy.sh)

Deployment fails on OSX due to complications in compiling RAPSearch, but was tested on Linux.  At time of submission, deployment on a cluster system was ongoing, but was successful at least to the installation of the biom-format package.

These scripts do not create search indexes from the data files, nor do they create configuration files after deployment has taken place.  These items will be addressed in new feature requests.
